### PR TITLE
add some examples for threaded applications

### DIFF
--- a/asyncio_examples.py
+++ b/asyncio_examples.py
@@ -7,12 +7,12 @@ the exact use case.
 import asyncio
 
 from proposal import tracer, helpers
-from proposal.active_span_source import NoopActiveSpanSource
+from proposal.active_span_source import AsyncioActiveSpanSource
 
 
 # set the NoopActiveSpanSource for those examples
 # TODO: move it somewhere else
-tracer._active_span_source = NoopActiveSpanSource()
+tracer._active_span_source = AsyncioActiveSpanSource()
 
 
 def coroutine_continue_propagation():
@@ -36,15 +36,15 @@ def coroutine_continue_propagation():
 def coroutine_with_callbacks():
     def success():
         span = tracer.active_span_source.active_span()
-        if span:
-            span.set_tag('result', 'success')
-            span.finish()
+        assert span is not None
+        span.set_tag('result', 'success')
+        span.finish()
 
     def failure():
         span = tracer.active_span_source.active_span()
-        if span:
-            span.set_tag('result', 'failure')
-            span.finish()
+        assert span is not None
+        span.set_tag('result', 'failure')
+        span.finish()
 
     async def do_async_work(cb_success, cb_failure):
         # executed in the main thread; do some IO-bound work

--- a/asyncio_examples.py
+++ b/asyncio_examples.py
@@ -1,8 +1,5 @@
 """Context propagation examples when dealing with single-threaded
 asyncio loops. It uses the Python 3.5+ syntax for simplicity.
-
-TODO: provide a better description for each example describing
-the exact use case.
 """
 import asyncio
 
@@ -16,6 +13,10 @@ tracer._active_span_source = AsyncioActiveSpanSource()
 
 
 def coroutine_continue_propagation():
+    """The asyncio loop executes two chained coroutines; the second
+    traced coroutine is a child of the first coroutine even if a
+    cooperative yield happens.
+    """
     async def do_async_work():
         # executed in the main thread
         with tracer.start_active(operation_name='some_work'):
@@ -34,6 +35,12 @@ def coroutine_continue_propagation():
 
 
 def coroutine_with_callbacks():
+    """The asyncio loop executes two chained coroutines with the
+    second one that expects a success callback (that is also a
+    coroutine). The callback that may be scheduled later because of
+    two cooperative yields, retrieves the right ActiveSpan, setting
+    a tag and finishing the Span.
+    """
     async def success():
         span = tracer.active_span_source.active_span()
         assert span is not None

--- a/asyncio_examples.py
+++ b/asyncio_examples.py
@@ -1,0 +1,73 @@
+"""Context propagation examples when dealing with single-threaded
+asyncio loops. It uses the Python 3.5+ syntax for simplicity.
+
+TODO: provide a better description for each example describing
+the exact use case.
+"""
+import asyncio
+
+from proposal import tracer, helpers
+from proposal.active_span_source import NoopActiveSpanSource
+
+
+# set the NoopActiveSpanSource for those examples
+# TODO: move it somewhere else
+tracer._active_span_source = NoopActiveSpanSource()
+
+
+def coroutine_continue_propagation():
+    async def do_async_work():
+        # executed in the main thread
+        with tracer.start_active(operation_name='some_work'):
+            # do some IO-bound work
+            pass
+
+    async def execute_job():
+        # executed in the main thread
+        with tracer.start_active(operation_name='execute_job'):
+            await do_async_work()
+            # ...do more work in this loop...
+
+    loop = asyncio.get_event_loop()
+    future = loop.create_task(execute_job())
+    loop.run_until_complete(future)
+
+
+def coroutine_with_callbacks():
+    def success():
+        span = tracer.active_span_source.active_span()
+        if span:
+            span.set_tag('result', 'success')
+            span.finish()
+
+    def failure():
+        span = tracer.active_span_source.active_span()
+        if span:
+            span.set_tag('result', 'failure')
+            span.finish()
+
+    async def do_async_work(cb_success, cb_failure):
+        # executed in the main thread; do some IO-bound work
+        span = tracer.start_active(operation_name='some_work')
+        is_success = True
+        if is_success:
+            cb_success()
+        else:
+            cb_failure()
+
+        # ...do more work that is not traced in some_work span...
+
+    async def execute_job():
+        # executed in the main thread
+        with tracer.start_active(operation_name='execute_job'):
+            await do_async_work(success, failure)
+            # ...do more work in this loop...
+
+    loop = asyncio.get_event_loop()
+    future = loop.create_task(execute_job())
+    loop.run_until_complete(future)
+
+
+if __name__ == '__main__':
+    coroutine_continue_propagation()
+    coroutine_with_callbacks()

--- a/proposal/active_span_source.py
+++ b/proposal/active_span_source.py
@@ -46,7 +46,7 @@ class ThreadActiveSpanSource():
         return getattr(self._locals, 'active_span', None)
 
 
-class AsyncioActiveSpanSource():
+class AsyncioActiveSpanSource(BaseActiveSpanSource):
     """This is a simplified implementation to make the asyncio examples
     work as expected. It uses the current Task instance as a carrier
     for of the current ActiveSpan available in this execution.

--- a/proposal/active_span_source.py
+++ b/proposal/active_span_source.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 
 
@@ -43,3 +44,30 @@ class ThreadActiveSpanSource():
     def active_span(self):
         # implementation detail
         return getattr(self._locals, 'active_span', None)
+
+
+class AsyncioActiveSpanSource():
+    """This is a simplified implementation to make the asyncio examples
+    work as expected. It uses the current Task instance as a carrier
+    for of the current ActiveSpan available in this execution.
+
+    Here we store the `active_span` but it could be anything else that
+    is used by Tracer developers.
+    """
+    def make_active(self, span, loop=None):
+        # implementation detail
+        # retrieves the current running loop if not provided
+        loop = loop or asyncio.get_event_loop()
+
+        # get the current running Task and set a new Span
+        task = asyncio.Task.current_task(loop=loop)
+        setattr(task, '__active_span', span)
+
+    def active_span(self, loop=None):
+        # implementation detail
+        # retrieves the current running loop if not provided
+        loop = loop or asyncio.get_event_loop()
+
+        # get the current running Task for this loop and return the ActiveSpan
+        task = asyncio.Task.current_task(loop=loop)
+        return getattr(task, '__active_span', None)

--- a/proposal/active_span_source.py
+++ b/proposal/active_span_source.py
@@ -1,3 +1,6 @@
+import threading
+
+
 class BaseActiveSpanSource(object):
     """BaseActiveSpanSource is the interface for a pluggable class that
     defines the source for the ActiveSpan. It must be used as a base class
@@ -20,3 +23,23 @@ class NoopActiveSpanSource(BaseActiveSpanSource):
 
     def active_span(self):
         return None
+
+
+class ThreadActiveSpanSource():
+    """This is a simplified implementation to make the multi-threading
+    examples work as expected. It uses a thread local storage to keep
+    track of the current ActiveSpan available in this thread execution.
+
+    Here we store the `active_span` but it could be anything else that
+    is used by Tracer developers.
+    """
+    def __init__(self):
+        self._locals = threading.local()
+
+    def make_active(self, span):
+        # implementation detail
+        setattr(self._locals, 'active_span', span)
+
+    def active_span(self):
+        # implementation detail
+        return getattr(self._locals, 'active_span', None)

--- a/proposal/active_span_source.py
+++ b/proposal/active_span_source.py
@@ -25,7 +25,7 @@ class NoopActiveSpanSource(BaseActiveSpanSource):
         return None
 
 
-class ThreadActiveSpanSource():
+class ThreadActiveSpanSource(BaseActiveSpanSource):
     """This is a simplified implementation to make the multi-threading
     examples work as expected. It uses a thread local storage to keep
     track of the current ActiveSpan available in this thread execution.

--- a/proposal/helpers.py
+++ b/proposal/helpers.py
@@ -22,23 +22,3 @@ class TracedThread(threading.Thread):
         tracer.active_span_source.make_active(self._active_span)
         del self._active_span
         super(TracedThread, self).run()
-
-
-class ThreadActiveSpanSource():
-    """This is a simplified implementation to make the multi-threading
-    examples work as expected. It uses a thread local storage to keep
-    track of the current ActiveSpan available in this thread execution.
-
-    Here we store the `active_span` but it could be anything else that
-    is used by Tracer developers.
-    """
-    def __init__(self):
-        self._locals = threading.local()
-
-    def make_active(self, span):
-        # implementation detail
-        setattr(self._locals, 'active_span', span)
-
-    def active_span(self):
-        # implementation detail
-        return getattr(self._locals, 'active_span', None)

--- a/proposal/helpers.py
+++ b/proposal/helpers.py
@@ -1,11 +1,12 @@
 """Helpers that are used in examples. In the current state, we may not require
 to put these classes and functions as part of the main proposal.
 """
-from threading import Thread
-from proposal import tracer
+import threading
+
+from proposal import Tracer, tracer
 
 
-class TracedThread(Thread):
+class TracedThread(threading.Thread):
     """Helper class OpenTracing-aware, that continues the propagation of
     the current ActiveSpan in a new thread using an internal wrapper.
     """
@@ -21,3 +22,23 @@ class TracedThread(Thread):
         tracer.active_span_source.make_active(self._active_span)
         del self._active_span
         super(TracedThread, self).run()
+
+
+class ThreadActiveSpanSource():
+    """This is a simplified implementation to make the multi-threading
+    examples work as expected. It uses a thread local storage to keep
+    track of the current ActiveSpan available in this thread execution.
+
+    Here we store the `active_span` but it could be anything else that
+    is used by Tracer developers.
+    """
+    def __init__(self):
+        self._locals = threading.local()
+
+    def make_active(self, span):
+        # implementation detail
+        setattr(self._locals, 'active_span', span)
+
+    def active_span(self):
+        # implementation detail
+        return getattr(self._locals, 'active_span', None)

--- a/proposal/helpers.py
+++ b/proposal/helpers.py
@@ -1,0 +1,23 @@
+"""Helpers that are used in examples. In the current state, we may not require
+to put these classes and functions as part of the main proposal.
+"""
+from threading import Thread
+from proposal import tracer
+
+
+class TracedThread(Thread):
+    """Helper class OpenTracing-aware, that continues the propagation of
+    the current ActiveSpan in a new thread using an internal wrapper.
+    """
+    def __init__(self, *args, **kwargs):
+        # implementation detail
+        # get the ActiveSpan when we're in the "parent" thread
+        self._active_span = tracer.active_span_source.active_span()
+        super(TracedThread, self).__init__(*args, **kwargs)
+
+    def run(self):
+        # implementation detail
+        # set the ActiveSpan in this thread and remove the local reference
+        tracer.active_span_source.make_active(self._active_span)
+        del self._active_span
+        super(TracedThread, self).run()

--- a/proposal/helpers.py
+++ b/proposal/helpers.py
@@ -3,7 +3,7 @@ to put these classes and functions as part of the main proposal.
 """
 import threading
 
-from proposal import Tracer, tracer
+from proposal import tracer
 
 
 class TracedThread(threading.Thread):

--- a/threaded_examples.py
+++ b/threaded_examples.py
@@ -1,0 +1,97 @@
+"""Context propagation examples when dealing with multi-threaded
+applications.
+
+TODO: provide a better description for each example describing
+the exact use case.
+"""
+import threading
+
+from proposal import tracer, helpers
+
+
+def main_thread_instrumented_only():
+    """The main thread is instrumented but not its children."""
+    def do_some_work():
+        # code executed in children threads
+        pass
+
+    # code executed in the main thread
+    with tracer.start_active(operation_name='main_thread') as span:
+        threads = [threading.Thread(target=do_some_work) for _ in range(5)]
+        for t in threads:
+            t.start()
+
+        # ...do more work in the main thread...
+        for t in threads:
+            t.join(timeout=1)
+
+
+def main_thread_instrumented_children_continue():
+    """The main thread is instrumented and when it spawns
+    new threads, they continue the main thread trace.
+    """
+    def do_some_work():
+        # code executed in children threads; it must continue
+        # the trace started in another thread
+        with tracer.start_active(operation_name='child_thread') as span:
+            pass
+
+    # code executed in the main thread
+    with tracer.start_active(operation_name='main_thread') as span:
+        threads = [helpers.TracedThread(target=do_some_work) for _ in range(5)]
+        for t in threads:
+            t.start()
+
+        # ...do more work in the main thread...
+        for t in threads:
+            t.join(timeout=1)
+
+
+def main_thread_instrumented_children_not_continue():
+    """The main thread is instrumented and when it spawns
+    new threads, they don't continue the main thread trace.
+    Each thread has its own trace.
+    """
+    def do_some_work():
+        # code executed in children threads; it doesn't continue
+        # the trace started in another thread
+        with tracer.start_active(operation_name='child_thread') as span:
+            pass
+
+    # code executed in the main thread
+    with tracer.start_active(operation_name='main_thread') as span:
+        threads = [threading.Thread(target=do_some_work) for _ in range(5)]
+        for t in threads:
+            t.start()
+
+        # ...do more work in the main thread...
+        for t in threads:
+            t.join(timeout=1)
+
+
+def main_thread_not_instrumented_children():
+    """The main thread is not instrumented but its children
+    are, each children has its own trace.
+    """
+    def do_some_work():
+        # code executed in children threads; it doesn't continue
+        # the trace started in another thread
+        with tracer.start_active(operation_name='child_thread') as span:
+            pass
+
+    # code executed in the main thread
+    threads = [threading.Thread(target=do_some_work) for _ in range(5)]
+    for t in threads:
+        t.start()
+
+    # ...do more work in the main thread...
+    for t in threads:
+        t.join(timeout=1)
+
+
+# will be moved somewhere else to keep the module only with examples
+if __name__ == '__main__':
+    main_thread_instrumented_only()
+    main_thread_instrumented_children_continue()
+    main_thread_instrumented_children_not_continue()
+    main_thread_not_instrumented_children()

--- a/threaded_examples.py
+++ b/threaded_examples.py
@@ -7,11 +7,12 @@ the exact use case.
 import threading
 
 from proposal import tracer, helpers
+from proposal.active_span_source import ThreadActiveSpanSource
 
 
 # set the ThreadActiveSpanSource for those examples
-# TODO: move it somewhere else
-tracer._active_span_source = helpers.ThreadActiveSpanSource()
+# TODO: move this init somewhere else
+tracer._active_span_source = ThreadActiveSpanSource()
 
 
 def main_thread_instrumented_only():


### PR DESCRIPTION
### What it does

Adds some examples that uses the `ActiveSpanSource` and the `TracedThread` available in the `Tracer` class and `helpers` module. This PR may need more work and may require changes in the API.

