### PR TITLE
add Tornado examples

### DIFF
--- a/examples/tornado.py
+++ b/examples/tornado.py
@@ -1,0 +1,58 @@
+"""Context propagation examples when dealing with single-threaded
+Tornado loops.
+"""
+from tornado import gen
+from tornado.ioloop import IOLoop
+
+from ext import tracer
+from ext.tornado.stack_context import TracerStackContext
+
+
+def coroutines_propagation():
+    """The Tornado loop executes two chained coroutines; the second
+    traced coroutine is a child of the first one even if a cooperative
+    yield happens. The propagation happens when a `TracerStackContext`
+    is used to provide a context-local storage.
+    """
+    @gen.coroutine
+    def coroutine_child():
+        active_span = tracer.active_span_source.active_span()
+        assert active_span is not None
+        with tracer.start_active(operation_name='coroutine_child'):
+            pass
+
+    @gen.coroutine
+    def entrypoint():
+        with tracer.start_active(operation_name='coroutine_parent') as span:
+            coro = [coroutine_child() for i in range(5)]
+            yield coro
+
+    # because we're tracing our execution within a TracerStackContext,
+    # the propagation is possible between coroutines. This is not a kind
+    # of feature flag, but it's a functionality that must be provided
+    # by the vendor or by the framework itself.
+    with TracerStackContext():
+        return entrypoint()
+
+
+def coroutines_without_propagation():
+    """The Tornado loop executes two chained coroutines; the second
+    traced coroutine is a child of the first one but because we're
+    outside of a `TracerStackContext` (or similar context-local storage)
+    a context-local storage is not available.
+    """
+    @gen.coroutine
+    def coroutine_child():
+        active_span = tracer.active_span_source.active_span()
+        assert active_span is None
+        with tracer.start_active(operation_name='coroutine_child'):
+            pass
+
+    @gen.coroutine
+    def entrypoint():
+        with tracer.start_active(operation_name='coroutine_parent') as span:
+            coro = [coroutine_child() for i in range(5)]
+            yield coro
+
+    # the propagation doesn't happen
+    return entrypoint()

--- a/ext/tornado/stack_context.py
+++ b/ext/tornado/stack_context.py
@@ -1,0 +1,60 @@
+from tornado.stack_context import StackContextInconsistentError, _state
+
+
+class TracerStackContext(object):
+    """A context manager that can be used to persist local states.
+    It must be used everytime a Tornado's handler or coroutine is traced.
+    It is meant to work like a traditional ``StackContext``, preserving the
+    state across asynchronous calls.
+
+    An ActiveSpan attached to a ``TracerStackContext`` is not shared between
+    different threads.
+
+    This simple implementation follows the suggestions provided here:
+    https://github.com/tornadoweb/tornado/issues/1063
+
+    This implementation is outside the scope of OpenTracing. Probably it's
+    something that may be provided by vendors or by the framework itself.
+    """
+    def __init__(self):
+        self.active = True
+        self.data = {}
+
+    def enter(self):
+        """Required to preserve the ``StackContext`` interface"""
+        pass
+
+    def exit(self, type, value, traceback):
+        """Required to preserve the ``StackContext`` interface"""
+        pass
+
+    def __enter__(self):
+        self.old_contexts = _state.contexts
+        self.new_contexts = (self.old_contexts[0] + (self,), self)
+        _state.contexts = self.new_contexts
+        return self
+
+    def __exit__(self, type, value, traceback):
+        final_contexts = _state.contexts
+        _state.contexts = self.old_contexts
+
+        if final_contexts is not self.new_contexts:
+            raise StackContextInconsistentError(
+                'stack_context inconsistency (may be caused by yield '
+                'within a "with TracerStackContext" block)')
+
+        # break the reference to allow faster GC on CPython
+        self.new_contexts = None
+
+    def deactivate(self):
+        self.active = False
+
+    @classmethod
+    def current_data(cls):
+        """Return the data for the current context. This method can be
+        used inside a Tornado coroutine to retrieve and use the current
+        tracing context.
+        """
+        for ctx in reversed(_state.contexts[0]):
+            if isinstance(ctx, cls) and ctx.active:
+                return ctx.data

--- a/requirements.in
+++ b/requirements.in
@@ -3,3 +3,6 @@ opentracing
 
 # libraries
 gevent
+
+# frameworks
+tornado

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ futures==3.1.1            # via opentracing
 gevent==1.2.2
 greenlet==0.4.12          # via gevent
 opentracing==1.2.2
+tornado==4.5.1

--- a/run_examples.py
+++ b/run_examples.py
@@ -3,12 +3,11 @@ from ext.active_span_source import (
     AsyncioActiveSpanSource,
     ThreadActiveSpanSource,
     GeventActiveSpanSource,
+    TornadoActiveSpanSource,
 )
 
-from examples import asyncio, multi_threaded, gevent
-
-
-# use a specific ActiveSpanSource implementation
+from tornado.ioloop import IOLoop
+from examples import asyncio, multi_threaded, gevent, tornado
 
 
 if __name__ == '__main__':
@@ -30,3 +29,8 @@ if __name__ == '__main__':
     gevent.main_greenlet_instrumented_children_continue()
     gevent.main_greenlet_instrumented_children_not_continue()
     gevent.main_greenlet_not_instrumented_children()
+
+    # tornado (starts / stops the loop for each call)
+    tracer._active_span_source = TornadoActiveSpanSource()
+    IOLoop.current().run_sync(tornado.coroutines_propagation)
+    IOLoop.current().run_sync(tornado.coroutines_without_propagation)

--- a/run_examples.py
+++ b/run_examples.py
@@ -34,3 +34,4 @@ if __name__ == '__main__':
     tracer._active_span_source = TornadoActiveSpanSource()
     IOLoop.current().run_sync(tornado.coroutines_propagation)
     IOLoop.current().run_sync(tornado.coroutines_without_propagation)
+    IOLoop.current().run_sync(tornado.coroutine_with_a_callback)

--- a/run_examples.py
+++ b/run_examples.py
@@ -35,3 +35,5 @@ if __name__ == '__main__':
     IOLoop.current().run_sync(tornado.coroutines_propagation)
     IOLoop.current().run_sync(tornado.coroutines_without_propagation)
     IOLoop.current().run_sync(tornado.coroutine_with_a_callback)
+    IOLoop.current().run_sync(tornado.tornado_plain_callback)
+    IOLoop.current().run_sync(tornado.tornado_spawn_callback)


### PR DESCRIPTION
### What it does

Adds some Tornado examples that can be used to improve the OT API. The current state makes use of a custom `StackContext` to provide a context-local storage. Main points:
* while (with a better implementation) this is working in many situations, it requires an extra helper from vendors (called `TracerStackContext` in this case)
* if an execution is not within a `TracerStackContext`, the context is not propagated between coroutines
* coroutines are used as example, but it's the same when dealing with async `RequestHandler`
* includes Tornado plain callbacks, added to the `IOLoop`
* includes Tornado callbacks executed when a `Future` is completed
* includes Tornado fire-and-forget callbacks that don't propagate the current active span

### Opened questions
* does the `ActiveSpanSource` need to fully support out-of-the-box this particular use case? Part of this functionality may be provided at some point by the framework itself (ref: https://github.com/tornadoweb/tornado/issues/1063), or by the specific implementation.
* in some cases we're already relying in (vendor?) helpers to provide automatic propagation (e.g. `TracedThread` that automatically passes the current context to a new thread), so this pattern may be considered similar?