### PR TITLE
add Gevent examples

### DIFF
--- a/examples/gevent.py
+++ b/examples/gevent.py
@@ -1,0 +1,71 @@
+"""Context propagation examples when using greenlet based
+concurrent programming.
+"""
+import gevent
+
+from ext import tracer, helpers
+
+
+def main_greenlet_instrumented_only():
+    """The main greenlet is instrumented but not its children."""
+    def do_some_work():
+        # code executed in children greenlets; they don't have an ActiveSpan
+        assert tracer.active_span_source.active_span() is None
+
+    # code executed in the main greenlet
+    with tracer.start_active(operation_name='main_greenlet') as span:
+        greenlets = [gevent.spawn(do_some_work) for _ in range(5)]
+        gevent.joinall(greenlets)
+
+
+def main_greenlet_instrumented_children_continue():
+    """The main greenlet is instrumented and when it spawns
+    new greenlets, they continue the main greenlet trace.
+    """
+    def do_some_work():
+        # code executed in children greenlets; it must continue
+        # the trace started in another greenlet
+        assert tracer.active_span_source.active_span() is not None
+        with tracer.start_active(operation_name='child_greenlet') as span:
+            pass
+
+    # code executed in the main greenlet
+    with tracer.start_active(operation_name='main_greenlet') as span:
+        greenlets = [helpers.TracedGreenlet.spawn(do_some_work) for _ in range(5)]
+        gevent.joinall(greenlets)
+
+
+def main_greenlet_instrumented_children_not_continue():
+    """The main greenlet is instrumented and when it spawns
+    new greenlets, they don't continue the main greenlet trace.
+    Each greenlet has its own trace.
+    """
+    def do_some_work():
+        # code executed in children greenlets; it doesn't continue
+        # the trace started in another greenlet
+        assert tracer.active_span_source.active_span() is None
+        with tracer.start_active(operation_name='child_greenlet') as span:
+            pass
+
+    # code executed in the main greenlet
+    with tracer.start_active(operation_name='main_greenlet') as span:
+        greenlets = [gevent.spawn(do_some_work) for _ in range(5)]
+
+    # don't wait for greenlets execution
+    gevent.joinall(greenlets)
+
+
+def main_greenlet_not_instrumented_children():
+    """The main greenlet is not instrumented but its children
+    are, each children has its own trace.
+    """
+    def do_some_work():
+        # code executed in children greenlets; it doesn't continue
+        # the trace started in another greenlet
+        assert tracer.active_span_source.active_span() is None
+        with tracer.start_active(operation_name='child_greenlet') as span:
+            pass
+
+    # code executed in the main greenlet
+    greenlets = [gevent.spawn(do_some_work) for _ in range(5)]
+    gevent.joinall(greenlets)

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,5 @@
 # OpenTracing API
 opentracing
+
+# libraries
+gevent

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 futures==3.1.1            # via opentracing
+gevent==1.2.2
+greenlet==0.4.12          # via gevent
 opentracing==1.2.2

--- a/run_examples.py
+++ b/run_examples.py
@@ -2,9 +2,10 @@ from ext import tracer
 from ext.active_span_source import (
     AsyncioActiveSpanSource,
     ThreadActiveSpanSource,
+    GeventActiveSpanSource,
 )
 
-from examples import asyncio, multi_threaded
+from examples import asyncio, multi_threaded, gevent
 
 
 # use a specific ActiveSpanSource implementation
@@ -22,3 +23,10 @@ if __name__ == '__main__':
     multi_threaded.main_thread_instrumented_children_continue()
     multi_threaded.main_thread_instrumented_children_not_continue()
     multi_threaded.main_thread_not_instrumented_children()
+
+    # gevent examples
+    tracer._active_span_source = GeventActiveSpanSource()
+    gevent.main_greenlet_instrumented_only()
+    gevent.main_greenlet_instrumented_children_continue()
+    gevent.main_greenlet_instrumented_children_not_continue()
+    gevent.main_greenlet_not_instrumented_children()


### PR DESCRIPTION
### What it does

Add `gevent` examples that behaves like the multithreading ones. A `TracedGreenlet` is provide to allow context propagation between different greenlets. the `GeventActiveSpanSource` is used to keep track of the current active `Span` using a greenlet local storage.