### PR TITLE
make explicit how a Span can be deactivated

### DIFF
--- a/ext/active_span_source.py
+++ b/ext/active_span_source.py
@@ -45,6 +45,9 @@ class AsyncioActiveSpanSource(BaseActiveSpanSource):
         task = asyncio.Task.current_task(loop=loop)
         setattr(task, '__active_span', span)
 
+        # explicitly set the flag for automatic deactivation
+        span._deactivate_on_finish = True
+
     def active_span(self, loop=None):
         # implementation detail
         # retrieves the current running loop if not provided

--- a/ext/active_span_source.py
+++ b/ext/active_span_source.py
@@ -37,6 +37,10 @@ class AsyncioActiveSpanSource(BaseActiveSpanSource):
         # retrieves the current running loop if not provided
         loop = loop or asyncio.get_event_loop()
 
+        # get the current active span and set the ancestor active Span
+        to_restore = self.active_span(loop=loop)
+        setattr(span, '_to_restore', to_restore)
+
         # get the current running Task and set a new Span
         task = asyncio.Task.current_task(loop=loop)
         setattr(task, '__active_span', span)
@@ -49,3 +53,21 @@ class AsyncioActiveSpanSource(BaseActiveSpanSource):
         # get the current running Task for this loop and return the ActiveSpan
         task = asyncio.Task.current_task(loop=loop)
         return getattr(task, '__active_span', None)
+
+    def deactivate(self, span, loop=None):
+        # implementation detail
+        # retrieves the current running loop if not provided
+        loop = loop or asyncio.get_event_loop()
+
+        # get the current active span and ignore if the current active branch
+        # is not the one we're trying to deactivate
+        active = self.active_span(loop=loop)
+        if span is not active:
+            return
+
+        # get span to restore
+        to_restore = getattr(span, '_to_restore', None)
+
+        # restore it
+        task = asyncio.Task.current_task(loop=loop)
+        setattr(task, '__active_span', to_restore)

--- a/proposal/__init__.py
+++ b/proposal/__init__.py
@@ -1,1 +1,2 @@
 from .tracer import Tracer  # noqa
+from .span import Span  # noqa

--- a/proposal/active_span_source.py
+++ b/proposal/active_span_source.py
@@ -4,12 +4,25 @@ class BaseActiveSpanSource(object):
     to implement the right behavior in the vendors specific implementation.
     """
     def make_active(self, span):
+        """Makes the given `span` active, so that it can be used as a parent
+        when calling the `start_active()` method of the Tracer. This method
+        must keep track of the active Span stack, so that the previous one
+        can be resumed when `span` is deactivated.
+        """
         raise NotImplementedError
 
-    def active_span(self, span):
+    def active_span(self):
+        """Returns the current active Span depending on the specific
+        implementation.
+        """
         raise NotImplementedError
 
     def deactivate(self, span):
+        """Deactivate the given `span`, restoring the previous active Span.
+        This method must take in consideration that a Span may be deactivated
+        when it's not really active. In that case, the current active stack
+        must not be changed.
+        """
         raise NotImplementedError
 
 

--- a/proposal/active_span_source.py
+++ b/proposal/active_span_source.py
@@ -9,6 +9,9 @@ class BaseActiveSpanSource(object):
     def active_span(self, span):
         raise NotImplementedError
 
+    def deactivate(self, span):
+        raise NotImplementedError
+
 
 class NoopActiveSpanSource(BaseActiveSpanSource):
     """ActiveSpanSource provides the logic to get and set the current
@@ -19,4 +22,7 @@ class NoopActiveSpanSource(BaseActiveSpanSource):
         return None
 
     def active_span(self):
+        return None
+
+    def deactivate(self, span):
         return None

--- a/proposal/span.py
+++ b/proposal/span.py
@@ -1,0 +1,27 @@
+from opentracing.span import Span as OTBaseTracer
+
+
+class Span(OTBaseTracer):
+    """Span class that provides some extensions to the Python OpenTracing API.
+    This class includes all methods that may be added to the OT Span class,
+    so that the proposed interface is public accessible
+    """
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Ends context manager and calls finish() on the span.
+        If exception has occurred during execution, it is automatically added
+        as a tag to the span.
+
+        Note: this method extends the current context manager
+        """
+        if exc_type:
+            self.log_kv({
+                'python.exception.type': exc_type,
+                'python.exception.val': exc_val,
+                'python.exception.tb': exc_tb,
+                })
+
+        # when the context manager is closed, we deactivate the current
+        # active Span before calling the finish()
+        self._tracer.active_span_source.deactivate(self)
+        self.finish()

--- a/proposal/span.py
+++ b/proposal/span.py
@@ -1,7 +1,7 @@
-from opentracing.span import Span as OTBaseTracer
+from opentracing.span import Span as OTBaseSpan
 
 
-class Span(OTBaseTracer):
+class Span(OTBaseSpan):
     """Span class that provides some extensions to the Python OpenTracing API.
     This class includes all methods that may be added to the OT Span class,
     so that the proposed interface is public accessible

--- a/proposal/tracer.py
+++ b/proposal/tracer.py
@@ -8,9 +8,9 @@ class Tracer(OTBaseTracer):
     API. This class includes all methods that may be added to the OT Tracer
     class, so that the proposed interface is public accessible.
     """
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         # create the tracer as defined in OpenTracing `Tracer` class
-        super(Tracer, self).__init__()
+        super(Tracer, self).__init__(*args, **kwargs)
         # this instance may be changed when the vendor specific
         # implementation is initialized
         self._active_span_source = NoopActiveSpanSource()
@@ -19,7 +19,19 @@ class Tracer(OTBaseTracer):
     def active_span_source(self):
         return self._active_span_source
 
-    def start_active(self, operation_name, tags=None, start_time=None):
+    def start_manual_span(self,
+                          operation_name=None,
+                          child_of=None,
+                          references=None,
+                          tags=None,
+                          start_time=None):
+        """This method supersede the original start_span. When developers
+        use that method, a new Span is created without changing the current
+        Span stack.
+        """
+        return self._noop_span
+
+    def start_active_span(self, operation_name, tags=None, start_time=None):
         """This is a simplified implementation to start a new Span
         that is marked as active.
         """


### PR DESCRIPTION
### What it does

In the base proposal, there isn't a way to manually deactivate the current active `Span`. This PR improves the API so that the `ActiveSpanSource` holds the logic to deactivate a span. The API has been implemented only in the `AsyncioActiveSpanSource` as a proof of concept. It will be part of all others `ActiveSpanSource` reference implementations.

Some notes about the reference implementation:
* when a `Span` is made active, the current active `Span` is stored in the newly activated `Span`. In that way, we behave like the `ActiveSpan` class in the Java-OT, while keeping the interface smaller (it's more Python specific)
* any `Span` instance can be deactivated using `tracer.active_span_source.deactivate(span)`
* if a `Span` is deactivated and it's the current active `Span`, the previous `Span` is restored using an attribute in the `Span` itself, that has been set when it was active
* if a `Span` is deactivated but it's not the current active `Span`, the current active `Span` stack is not changed and the action is a noop
* finishing a `Span` doesn't mean deactivating it, neither the opposite. These are two different APIs that don't alter the default `Span` behavior
* the `Span` context manager has been updated so that the span is automatically deactivated when exiting from the context